### PR TITLE
Replace better-sqlite3 with mysql2 references

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,20 +118,21 @@ npm run db:reset              # Drops all tables and recreates with seed data
 
 ## 📊 Database
 
-- **Type**: SQLite3
-- **Location**: `server/data/innovation-manager.db`
+- **Type**: MySQL
+- **Host**: localhost (default)
+- **Database**: innovation_manager
 - **Tables**: users, initiatives, stage_transitions, ai_interactions
 - **Demo Data**: 6 users, 12 initiatives across 4 stages
 
 ### Inspect Database
 ```bash
-cd server
-npx better-sqlite3 data/innovation-manager.db
+# Connect to MySQL
+mysql -u root -p innovation_manager
 
 # SQL commands:
 SELECT * FROM users;
 SELECT * FROM initiatives;
-.exit
+EXIT;
 ```
 
 ---
@@ -142,7 +143,7 @@ SELECT * FROM initiatives;
 |-----------|-----------|
 | **Frontend** | React 18 + Vite + Tailwind CSS |
 | **Backend** | Node.js + Express.js |
-| **Database** | SQLite3 (better-sqlite3) |
+| **Database** | MySQL (mysql2) |
 | **AI** | Anthropic Claude API (future) |
 
 ---
@@ -179,16 +180,21 @@ lsof -ti:5173 | xargs kill
 npm run db:reset
 ```
 
-### SQLite installation fails
+### MySQL installation
 **macOS:**
 ```bash
-xcode-select --install
+brew install mysql
+brew services start mysql
 ```
 
 **Ubuntu/Debian:**
 ```bash
-sudo apt-get install build-essential python3
+sudo apt-get install mysql-server
+sudo systemctl start mysql
 ```
+
+**Windows:**
+Download and install from https://dev.mysql.com/downloads/mysql/
 
 ### Clear and reinstall
 ```bash

--- a/SETUP.md
+++ b/SETUP.md
@@ -26,7 +26,7 @@ cd ..
 
 This installs:
 - express
-- better-sqlite3 (SQLite database)
+- mysql2 (MySQL database driver)
 - cors, helmet (security)
 - morgan (logging)
 - bcrypt, jsonwebtoken (authentication)
@@ -63,7 +63,7 @@ Edit `.env` if needed. For now, defaults are fine. You'll add the Anthropic API 
 
 ## Step 5: Initialize Database
 
-This creates the SQLite database, tables, and seeds demo data:
+This creates the MySQL database, tables, and seeds demo data:
 
 ```bash
 npm run db:reset
@@ -72,8 +72,8 @@ npm run db:reset
 Expected output:
 ```
 🔄 Starting database reset...
-📁 Creating data directory...
-✨ Creating new database...
+🗄️  Connecting to MySQL...
+✨ Creating database...
 📋 Creating schema...
 ✅ Schema created successfully
 🌱 Seeding data...
@@ -85,7 +85,7 @@ Expected output:
    Stage Transitions: 3
 
 ✅ Database reset completed successfully!
-📍 Database location: /path/to/server/data/innovation-manager.db
+📍 Database: innovation_manager
 
 🔑 Demo User Credentials:
    employee@demo.com (EMPLOYEE) - Password: demo123
@@ -155,25 +155,15 @@ You should see:
 
 ## Step 8: Verify Database
 
-Check that the database file was created:
+You can inspect the database using the MySQL client:
 
 ```bash
-ls -lh server/data/
-
-# Should show:
-# innovation-manager.db
-```
-
-You can inspect the database with any SQLite browser, or use:
-
-```bash
-cd server
-npx better-sqlite3 data/innovation-manager.db
+mysql -u root -p innovation_manager
 
 # Then run SQL:
 # SELECT COUNT(*) FROM users;      -- Should return 6
 # SELECT COUNT(*) FROM initiatives; -- Should return 12
-# .exit
+# EXIT;
 ```
 
 ---
@@ -198,24 +188,24 @@ lsof -ti:5173 | xargs kill
 
 Or change ports in `.env` (for backend) and `client/vite.config.js` (for frontend).
 
-### SQLite installation issues
+### MySQL installation
 
-If `better-sqlite3` fails to install, you may need to install build tools:
+If MySQL is not installed:
 
 **macOS:**
 ```bash
-xcode-select --install
+brew install mysql
+brew services start mysql
 ```
 
 **Ubuntu/Debian:**
 ```bash
-sudo apt-get install build-essential python3
+sudo apt-get install mysql-server
+sudo systemctl start mysql
 ```
 
 **Windows:**
-```bash
-npm install --global windows-build-tools
-```
+Download and install from https://dev.mysql.com/downloads/mysql/
 
 ---
 
@@ -240,7 +230,7 @@ Innovation-LifeCycle-Manager/
 │   │   ├── seed.sql     ← Demo data
 │   │   └── reset.js     ← Reset script
 │   └── data/
-│       └── innovation-manager.db ← SQLite database
+│       └── (MySQL database - external)
 │
 └── client/              ← Frontend
     ├── package.json

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -69,19 +69,21 @@
 
 ### Database
 
-**Primary Database**: SQLite3
+**Primary Database**: MySQL
 **Why**:
-- ✅ No installation required
-- ✅ No admin rights needed
-- ✅ File-based (single .db file)
-- ✅ Zero configuration
-- ✅ Sufficient for demo and small-scale production
-- ✅ Can be upgraded to PostgreSQL later without major code changes
+- ✅ Production-ready relational database
+- ✅ Wide industry adoption and support
+- ✅ Excellent performance for medium to large-scale applications
+- ✅ ACID compliant with strong data integrity
+- ✅ Rich ecosystem of tools and libraries
+- ✅ Can scale vertically and horizontally
 
-**ORM/Query Builder**: Better-SQLite3 + Knex.js
+**Database Driver**: mysql2
 **Why**:
-- `better-sqlite3`: Synchronous API, faster than async sqlite3
-- `knex.js`: Query builder, migrations, works with multiple databases
+- Modern MySQL client for Node.js
+- Promise-based API
+- Supports prepared statements
+- Better performance than older mysql package
 
 **AI/Vector Storage**: In-memory cache + Claude API
 **Why**:

--- a/scripts/test-setup.sh
+++ b/scripts/test-setup.sh
@@ -35,8 +35,8 @@ run_test() {
     fi
 }
 
-# 1. Check if database file exists
-run_test "Database file exists" "[ -f server/data/innovation-manager.db ]"
+# 1. Check if MySQL is running
+run_test "MySQL is accessible" "mysql -u root --password='' -e 'SELECT 1' &> /dev/null || mysql -u root -e 'SELECT 1' &> /dev/null"
 
 # 2. Check if backend is running
 run_test "Backend health check" "curl -f -s http://localhost:3000/health > /dev/null"
@@ -54,8 +54,8 @@ else
 fi
 
 # 5. Check database has users
-USER_COUNT=$(cd server && npx --yes better-sqlite3 data/innovation-manager.db "SELECT COUNT(*) as count FROM users" --json 2>/dev/null | grep -o '"count":[0-9]*' | grep -o '[0-9]*')
-if [ "$USER_COUNT" -ge 6 ]; then
+USER_COUNT=$(mysql -u root --password='' -e "SELECT COUNT(*) as count FROM innovation_manager.users" -sN 2>/dev/null || mysql -u root -e "SELECT COUNT(*) as count FROM innovation_manager.users" -sN 2>/dev/null)
+if [ -n "$USER_COUNT" ] && [ "$USER_COUNT" -ge 6 ]; then
     echo -e "Testing: Database has users (count: $USER_COUNT)... ${GREEN}✅ PASS${NC}"
     ((TESTS_PASSED++))
 else
@@ -64,8 +64,8 @@ else
 fi
 
 # 6. Check database has initiatives
-INITIATIVE_COUNT=$(cd server && npx --yes better-sqlite3 data/innovation-manager.db "SELECT COUNT(*) as count FROM initiatives" --json 2>/dev/null | grep -o '"count":[0-9]*' | grep -o '[0-9]*')
-if [ "$INITIATIVE_COUNT" -ge 12 ]; then
+INITIATIVE_COUNT=$(mysql -u root --password='' -e "SELECT COUNT(*) as count FROM innovation_manager.initiatives" -sN 2>/dev/null || mysql -u root -e "SELECT COUNT(*) as count FROM innovation_manager.initiatives" -sN 2>/dev/null)
+if [ -n "$INITIATIVE_COUNT" ] && [ "$INITIATIVE_COUNT" -ge 12 ]; then
     echo -e "Testing: Database has initiatives (count: $INITIATIVE_COUNT)... ${GREEN}✅ PASS${NC}"
     ((TESTS_PASSED++))
 else


### PR DESCRIPTION
- Update README.md to reference MySQL instead of SQLite
- Update SETUP.md with MySQL installation and usage instructions
- Update ARCHITECTURE.md database section to use mysql2
- Update setup-and-run.sh to check for MySQL instead of Python
- Update test-setup.sh to query MySQL database
- Update setup-and-run.bat for Windows MySQL support
- Update test-setup.bat with MySQL queries
- Remove all references to better-sqlite3
- Update database inspection commands to use MySQL CLI